### PR TITLE
Update the appearance of the build_and_register output

### DIFF
--- a/custom-targets/util/build_and_register.sh
+++ b/custom-targets/util/build_and_register.sh
@@ -25,7 +25,7 @@ usage() {
 }
 
 boldout() {
-  echo $(tput bold)$(tput setaf 1)"$@"$(tput sgr0)
+  echo $(tput bold)$(tput setaf 2)">> $@"$(tput sgr0)
 }
 
 while getopts "p:r:" arg; do


### PR DESCRIPTION
The primary log lines are now green and start with ">> ".